### PR TITLE
Implement the lang flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ go test ./...
 ## Usage:
 ```
 ./example-finder search TEXT [-l|--lang LANG] [-t|--token TOKEN] [-m|--mode MODE] [-r|--results num]
-  lang    - language to return results in (not implemented yet)
+  lang    - language to return results in
   token   - Github API token, see https://github.com/settings/tokens - should be inside .token file
   mode    - currently only REST mode is supported, a future plan is to support GraphQL as well
   results - number of results per page to return (default 30)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -46,8 +46,12 @@ var searchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		switch mode {
 		case "rest":
+			co := rest.ClientOptions{
+				ResultsPerPage: resultsPerPage,
+				Lang:           lang,
+			}
 			// TODO: handle errors and stuff
-			client, _ := rest.New(token, resultsPerPage, initDb())
+			client, _ := rest.New(token, &co, initDb())
 			results := client.Search(args[0], lang)
 
 			fmt.Println()


### PR DESCRIPTION
Using -l or --lang will now make the search return repos in the requested language