### PR TITLE
collect paths to result files

### DIFF
--- a/backend/result.go
+++ b/backend/result.go
@@ -2,10 +2,11 @@ package backends
 
 // Result hold the result to amount of stars mapping
 type Result struct {
-	RepoID   int64
-	RepoName string
-	RepoURL  string
-	Stars    int
+	RepoID    int64
+	RepoName  string
+	RepoURL   string
+	Stars     int
+	FilePaths []string
 }
 
 // ByStars a type to sort results by stars

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -57,6 +57,11 @@ var searchCmd = &cobra.Command{
 			fmt.Println()
 			for _, r := range results {
 				fmt.Printf("repo: %s \n\t%s\n\tstars: %d\n", r.RepoName, r.RepoURL, r.Stars)
+				fmt.Printf("\tfiles:\n")
+				// TODO: extract this
+				for _, path := range r.FilePaths {
+					fmt.Printf("\t %v\n", path)
+				}
 			}
 		}
 	},


### PR DESCRIPTION
This PR adds the paths to the files containing the search results (see #9), for example:
<pre>
repo: api 
	https://github.com/bs-online-judge/api
	stars: 0
	files:
	 https://github.com/bs-online-judge/api/blob/7919a84c61f1ad9be019ec8ddb2febcaa486d1dd/models/schema.go
</pre>

But more work should be done as this solution is pretty naive, and always overrides the current paths.
We should keep the hash and check whether the results should actually be refreshed or not.